### PR TITLE
Fix dependencies in .toml and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "copycatbmi"
-version = "0.0.1"
+version = "0.0.3"
+dependencies = [
+  "numpy>=1.26.4",
+  "xarray>=2024.7.0",
+  "PyYAML>=6.0.3",
+  "bmipy>=2.0.1"
+]
 authors = [
   { name="Matt Williamson" },
 ]


### PR DESCRIPTION
Add dependencies to auto-install to `pyproject.toml`, and bump version to 0.0.3

## Additions

- Added numpy, xarray, PyYAML, and bmipy as explicit dependencies

## Removals

- NA

## Changes

- version => 0.0.3

## Testing

1. Reinstall in venv now brings along correct dependencies

## Screenshots


## Notes

- Does NOT specify netcdf4 or h5netcdf, though one or the other must be present (and only tested so far with netcdf4)!

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [X] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
