### PR TITLE
BUG: Q units still not right

### DIFF
--- a/src/copycatbmi/bmi.py
+++ b/src/copycatbmi/bmi.py
@@ -134,7 +134,7 @@ class CopyCat(BmiBase):
         ds = self._get_dataset()
         logger.info(self._feature_id)
         logger.info(ds['streamflow'][(ds['feature_id'] == self._feature_id)].values[0])
-        self._q = ds['streamflow'][(ds['feature_id'] == self._feature_id)].values[0] / self._area_sqm
+        self._q = 3600 * ds['streamflow'][(ds['feature_id'] == self._feature_id)].values[0] / self._area_sqm
         self._qvar = np.array([self._q], dtype=np.float32)
 
     def get_time_step(self) -> float:


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- NA

## Removals

- NA

## Changes

- Divides Q output by 3600 (m/s -> m/h)

## Testing

1. Run in ngen, producing correct output through to routing now.

## Screenshots


## Notes

- See also #1 

## Todos

- NA

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
