### PR TITLE
Fix failures when feature_id is missing, in BMI and t-route scenarios.

### DIFF
--- a/src/copycatbmi/bmi.py
+++ b/src/copycatbmi/bmi.py
@@ -95,7 +95,12 @@ class CopyCat(BmiBase):
         result = ds['streamflow'][(ds['feature_id'] == self._feature_id)]
         if result.isnull():
             logger.warning(f"Got NaN for feature {self._feature_id} at tN={self._tN}, using zero.")
-        self._q = 3600 * result.fillna(0).values[0] / self._area_sqm
+            self._q = 0
+        elif len(result.values) == 0:
+            logger.warning(f"Got no results for feature {self._feature_id} at tN={self._tN} (non-existent reach?), returning zero.")
+            self._q = 0
+        else:
+            self._q = 3600 * result.values[0] / self._area_sqm
         self._qvar = np.array([self._q], dtype=np.float32)
 
     def get_time_step(self) -> float:

--- a/src/copycatbmi/troute.py
+++ b/src/copycatbmi/troute.py
@@ -18,14 +18,22 @@ class TRouteWarmer():
 
 
     def make_channel_restart_file(self, tm1: datetime, features: dict[int,int], dest: Union[str, Path]):
-        flowpath_ids = list(features.keys())
         feature_ids = list(features.values())
         with SourceManager(self._cache_dir) as sm:
             source = sm.derive_source(t0=tm1, tend=tm1, source_base=self._source_base)
             ds = sm.get_dataset(source, 0)
 
-            # Get count of NaNs in the `streamflow` variable and issue a warning if there are more than 0...
+            missing = [feature_id for feature_id in feature_ids if feature_id not in ds.coords['feature_id'].values]
+            if len(missing) > 0:
+                logger.warning(f"Got {len(missing)} feature IDs not found in datset! These will be omitted!")
+                logger.info(f"Missing feature_ids: {missing}")
+                # rebuild features
+                features = { fpid: fid for fpid, fid in features.items() if fid not in missing }
+                feature_ids = list(features.values())
+            flowpath_ids = list(features.keys())
             ds = ds.sel(feature_id=feature_ids)
+
+            # Get count of NaNs in the `streamflow` variable and issue a warning if there are more than 0...
             nan_count = int(ds['streamflow'].isnull().sum().values)
             if nan_count > 0:
                 logger.warning(f"Dataset has {nan_count} NaN values in `streamflow` variable. Filling with 0.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 """Pytest configuration and shared fixtures."""
 
+from datetime import datetime
+import numpy as np
 import pytest
 import tempfile
 from pathlib import Path
+
+import xarray as xr
 
 
 @pytest.fixture
@@ -10,4 +14,30 @@ def temp_cache_dir():
     """Create a temporary cache directory for tests."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
+
+@pytest.fixture
+def mock_dataset_partial_features():
+    """
+    Create a mock xarray Dataset that contains only some of the requested feature_ids.
+    This will trigger a KeyError when trying to select non-existent feature_ids.
+    """
+    # Create a dataset with only feature_ids 100 and 101
+    feature_ids = [100, 101]
+    times = [datetime(2024, 1, 1, 12, 0, 0)]
+    
+    data = {
+        'streamflow': (['feature_id', 'time'], np.array([
+            [1.5],  # feature_id 100
+            [2.5],  # feature_id 101
+        ]))
+    }
+    
+    coords = {
+        'feature_id': feature_ids,
+        'time': times
+    }
+    
+    ds = xr.Dataset(data, coords=coords)
+    return ds
+
 

--- a/tests/test_bmi.py
+++ b/tests/test_bmi.py
@@ -1,0 +1,50 @@
+"""Tests for the TRouteWarmer class."""
+
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+from copycatbmi.bmi import CopyCat
+
+
+class TestCopyCat:
+    """Tests for CopyCat class."""
+
+    def test_update_until_missing_feature_id(self, mock_dataset_partial_features, tmp_path):
+        """
+        Test that update_until does not raise KeyError when feature_id 
+        is missing from the dataset.
+        """
+        
+        bmi = CopyCat()
+        
+        with patch('copycatbmi.troute.SourceManager') as mock_sm_class:
+            # Setup the mock SourceManager
+            mock_sm_instance = MagicMock()
+            mock_sm_class.return_value.__enter__.return_value = mock_sm_instance
+            
+            # Setup the mock source
+            mock_source = Mock()
+            #mock_sm_instance.derive_source.return_value = mock_source
+            
+            # Setup the mock dataset to return the actual xarray dataset fixture
+            # This will trigger KeyError on .sel() for missing feature_ids
+            mock_sm_instance.get_dataset.return_value = mock_dataset_partial_features
+            
+            # Set up CopyCat state
+            bmi._feature_id = 102
+            bmi._area_sqm = 10
+            bmi._source_manager = mock_sm_instance
+            bmi._source = mock_source
+            
+            # This should raise a KeyError because feature_ids 102 and 103 are not in the dataset
+            #with pytest.raises(KeyError, match="not all values found in index 'feature_id'"):
+            bmi.update_until(3600)
+
+        qvar = np.array([-1.0], dtype=np.float32)
+        bmi.get_value('Q', qvar)
+        assert qvar[0] == 0.0

--- a/tests/test_troute.py
+++ b/tests/test_troute.py
@@ -1,0 +1,54 @@
+"""Tests for the TRouteWarmer class."""
+
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+from copycatbmi.troute import TRouteWarmer
+
+
+class TestTRouteWarmer:
+    """Tests for TRouteWarmer class."""
+
+    def test_make_channel_restart_file_missing_feature_ids(self, mock_dataset_partial_features, tmp_path):
+        """
+        Test that make_channel_restart_file does not raise KeyError when feature_ids 
+        are missing from the dataset.
+        
+        The features dict maps flowpath_ids to feature_ids. We pass features where
+        some feature_ids (102, 103) do not exist in the dataset, while others (100, 101) do.
+        """
+        # features maps flowpath_id -> feature_id
+        # Some feature_ids exist in the dataset (100, 101), others don't (102, 103)
+        features = {
+            1: 100,  # exists in dataset
+            2: 101,  # exists in dataset
+            3: 102,  # DOES NOT exist in dataset - will cause KeyError
+            4: 103,  # DOES NOT exist in dataset - will cause KeyError
+        }
+        
+        tm1 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        dest = tmp_path / "restart.pkl"
+        
+        warmer = TRouteWarmer(cache_dir=None, source_base=None)
+        
+        with patch('copycatbmi.troute.SourceManager') as mock_sm_class:
+            # Setup the mock SourceManager
+            mock_sm_instance = MagicMock()
+            mock_sm_class.return_value.__enter__.return_value = mock_sm_instance
+            
+            # Setup the mock source
+            mock_source = Mock()
+            mock_sm_instance.derive_source.return_value = mock_source
+            
+            # Setup the mock dataset to return the actual xarray dataset fixture
+            # This will trigger KeyError on .sel() for missing feature_ids
+            mock_sm_instance.get_dataset.return_value = mock_dataset_partial_features
+            
+            # This should raise a KeyError because feature_ids 102 and 103 are not in the dataset
+            #with pytest.raises(KeyError, match="not all values found in index 'feature_id'"):
+            warmer.make_channel_restart_file(tm1, features, dest)


### PR DESCRIPTION
Where a NWM feature_id is retrieved from the hydrofabric but not present in the channel_rt output, both TRouteWarmer and CopyCat (BMI) may fail. The cause of this could be an error in the NextGen Hydrofabric or an unexpected condition in the channel_rt output, but it is far from impossible and shouldn't fail.

## Additions

- Tests for condition where the feature_id is missing in TRouteWarmer
- Tests for condition where the feature_id is missing in CopyCat (BMI)

## Removals

- NA

## Changes

- CopyCat now returns zero if a non-existent feature_id is specified and issues a warning
- TRouteWarmer omits missing features from the warm-start file

## Testing

1. Automated tests added and passed

## Screenshots


## Notes

- NA

## Todos

- NA

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Target Environment support

- [X] Linux

