### PR TITLE
Overhaul of parallelism/locking

### DIFF
--- a/src/copycatbmi/source_manager.py
+++ b/src/copycatbmi/source_manager.py
@@ -98,6 +98,10 @@ class SourceManager(metaclass=SingletonMeta):
         }
     }
 
+    # for same-process re-use of derived sources.
+    # Should probably only ever contain one item.
+    _source_cache = {} 
+
     def __init__(self, cache_dir) -> None:
         self._entries = 0
         self._is_leader = False
@@ -124,6 +128,10 @@ class SourceManager(metaclass=SingletonMeta):
         return False
 
     def derive_source(self, t0: datetime, tend: Optional[datetime] = None, source_base: Optional[str] = None) -> Source:
+        cache_key = (t0, tend, source_base)
+        if cache_key in SourceManager._source_cache:
+            return SourceManager._source_cache[cache_key]
+        
         # A source_base config entry can be a specific starting FILE, OR a 
         # known source key OR a URL or filesystem path to a NOMADS-style 
         # directory structure leading to model files.
@@ -239,7 +247,9 @@ class SourceManager(metaclass=SingletonMeta):
             if t0_fnum + t0_tend_delta_hours > model_hours:
                 raise ValueError(f"Simulation end date {tend} exceeds the data available for model {variant_info['model_name']} when starting at forecast hour {t0_fnum} (init_time {attempt.strftime('%Y%m%d')})")
 
-        return Source(base, base_url, t0_fnum)
+        source = Source(base, base_url, t0_fnum)
+        SourceManager._source_cache[cache_key] = source
+        return source
 
     def get_dataset(self, source: Source, tN: int) -> xr.Dataset:
         max_retries = 5

--- a/src/copycatbmi/source_manager.py
+++ b/src/copycatbmi/source_manager.py
@@ -390,6 +390,12 @@ class SourceManager(metaclass=SingletonMeta):
         except Exception as e:
             logger.error(f"Failed to release lock on leader file--this could cause subsequent issues!")
             logger.debug(str(e))
+        
+        try:
+            (self._cache_dir / 'leader.id').unlink()
+            (self._cache_dir / 'source.json').unlink(missing_ok=True)
+        except Exception as e:
+            logger.warning(f"Failed to clean up leader files (check permissions?)")
 
         self._is_leader = False
 

--- a/src/copycatbmi/source_manager.py
+++ b/src/copycatbmi/source_manager.py
@@ -1,4 +1,5 @@
 import fcntl
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePath, PosixPath, PurePosixPath
@@ -38,7 +39,14 @@ class SingletonMeta(type):
         return cls._instances[cls]
     
 class Source():
-    def __init__(self, base, base_url, t0_fnum):
+    def __init__(self, base: Union[PurePath,str], base_url: Union[ParseResult,str], t0_fnum: int):
+        if not isinstance(base_url, ParseResult):
+            base_url = urlparse(base_url) 
+        if not isinstance(base, PurePath):
+            if base_url.scheme != '':
+                base = PurePosixPath(base)
+            else:
+                base = Path(base)
         self._base = base
         self._base_url = base_url
         self._t0_fnum = t0_fnum
@@ -132,6 +140,35 @@ class SourceManager(metaclass=SingletonMeta):
         if cache_key in SourceManager._source_cache:
             return SourceManager._source_cache[cache_key]
         
+        psource = None
+        if self._cache_dir:
+            psource = self._cache_dir / 'source.json'
+
+        # If we are not the leader, wait for the leader to drop a source file...
+        if psource and not self._is_leader:
+            waitmax = 300 #TODO: Make configurable?
+            waitstep = 2
+            waited = 0
+            while True:
+                logger.info(f"Waiting for leader to drop source.json, waited {waited}s...")
+                source = None
+                try:
+                    if psource.exists():
+                        with open(psource, 'r') as fsource:
+                            source_dict = json.load(fsource)
+                            source = Source(**source_dict)
+                            SourceManager._source_cache[cache_key] = source
+                            return source # Infinite loop ends here normally
+                except:
+                    pass
+                if not source and waited < waitmax:
+                    time.sleep(waitstep)
+                    waited += waitstep
+                if waited >= waitmax and not psource.exists():
+                    logger.critical(f"Waited >={waitmax}s for {psource.name} to arrive. Timed out!")
+                    raise RuntimeError(f"Waited >={waitmax}s for {psource.name} to arrive. Timed out!")
+
+        logger.info(f"Leader {self._uuid} deriving source...")
         # A source_base config entry can be a specific starting FILE, OR a 
         # known source key OR a URL or filesystem path to a NOMADS-style 
         # directory structure leading to model files.
@@ -246,6 +283,15 @@ class SourceManager(metaclass=SingletonMeta):
             t0_tend_delta_hours = (tend - t0).total_seconds() // 3600
             if t0_fnum + t0_tend_delta_hours > model_hours:
                 raise ValueError(f"Simulation end date {tend} exceeds the data available for model {variant_info['model_name']} when starting at forecast hour {t0_fnum} (init_time {attempt.strftime('%Y%m%d')})")
+
+        if psource:
+            with open(psource, 'w') as fsource:
+                json.dump({
+                    'base': str(base),
+                    'base_url': base_url.geturl(),
+                    't0_fnum': t0_fnum
+                }, fsource)
+            #with open(psource, 'r') as f: print(f.read())
 
         source = Source(base, base_url, t0_fnum)
         SourceManager._source_cache[cache_key] = source

--- a/src/copycatbmi/source_manager.py
+++ b/src/copycatbmi/source_manager.py
@@ -113,6 +113,7 @@ class SourceManager(metaclass=SingletonMeta):
     def __init__(self, cache_dir) -> None:
         self._entries = 0
         self._is_leader = False
+        self._leader_lock_fd = None
         self._uuid: uuid.UUID = uuid.uuid4()
         if cache_dir is not None:
             self._cache_dir = Path(cache_dir)
@@ -361,14 +362,17 @@ class SourceManager(metaclass=SingletonMeta):
             return
         try:
             self._cache_dir.mkdir(parents=True, exist_ok=True)
-            with open(self._cache_dir/'leader.id', "a") as f:
-                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB) # Try to acquire exclusive lock
-                self._is_leader = True
-                f.seek(0)
-                f.truncate()
-                f.write(str(self._uuid))
-                f.flush()
-                return
+            self._leader_lock_fd = open(self._cache_dir/'leader.id', "a")
+            fcntl.flock(self._leader_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB) # Try to acquire exclusive lock
+            self._is_leader = True
+            self._leader_lock_fd.seek(0)
+            self._leader_lock_fd.truncate()
+            self._leader_lock_fd.write(str(self._uuid))
+            self._leader_lock_fd.flush()
+            (self._cache_dir / 'source.json').unlink(missing_ok=True)
+
+
+            return
         except BlockingIOError:
             pass
         except Exception as e:
@@ -380,13 +384,12 @@ class SourceManager(metaclass=SingletonMeta):
         if not self._cache_dir or not self._is_leader:
             return
         try:
-            with open(self._cache_dir/'leader.id', "a") as f:
-                fcntl.flock(f, fcntl.LOCK_UN) # Release exclusive lock
-                self._is_leader = False
-                return
+            fcntl.flock(self._leader_lock_fd, fcntl.LOCK_UN) # Release exclusive lock
+            self._leader_lock_fd.close()
+            self._is_leader = False
         except Exception as e:
-            logger.critical(f"Unexpected error releasing leader lock! Seppuku to ensure lock release!")
-            raise e
+            logger.error(f"Failed to release lock on leader file--this could cause subsequent issues!")
+            logger.debug(str(e))
 
         self._is_leader = False
 

--- a/tests/test_source_manager.py
+++ b/tests/test_source_manager.py
@@ -1,6 +1,7 @@
 """Tests for the SourceManager class."""
 
 from urllib.error import HTTPError
+from urllib.parse import urlparse
 import pytest
 import tempfile
 from pathlib import Path
@@ -18,10 +19,22 @@ class TestSource:
     def test_source_initialization(self):
         """Test Source object initialization."""
         base = Path("/path/to/file.nc")
-        base_url = "http://example.com/data/"
+        base_url = urlparse("http://example.com/data/")
         t0_fnum = 123
         
         source = Source(base, base_url, t0_fnum)
+        
+        assert source.base == base
+        assert source.base_url == base_url
+        assert source.t0_fnum == t0_fnum
+
+    def test_source_initialization_strings(self):
+        """Test Source object initialization."""
+        base = Path("/path/to/file.nc")
+        base_url = urlparse("http://example.com/data/")
+        t0_fnum = 123
+        
+        source = Source(str(base), base_url.geturl(), t0_fnum)
         
         assert source.base == base
         assert source.base_url == base_url


### PR DESCRIPTION
Probably the real fixes for #5 . See notes.
 
## Additions

- Source is (properly) derived once and cached within the singleton (within a single process) and written to a .json file for pickup by instances not sharing the singleton (for multiple processes).

## Removals

- Non-leader singletons cannot proceed with source derivation and must rely on the leader

## Changes

- `Source` object can now be instantiated with urllib.ParseResult object and PurePath object (original intention) _or_ with strings (easier for instantiating from JSON-serialized source)--tests updated to reflect this.
- The leader lock file (leader.id) now has a file handle held open for the whole execution cycle of the leader (as a context manager, specifically).

## Testing

1. Tests updated and passing
2. Ran 8-process 24h simulations without file corruption in downloaded channel_rt files

## Screenshots


## Notes

- The main reason the existing code wasn't working is because the exclusive lock was released when the `when` block opening the file exited (and thus the file descriptor was released)--I incorrectly believed the lock would persist independently of the writable file handle.
- There may be potential for improper releasing of the file descriptor (leaking file handles??) under unforeseen circumstances, as the file handle is now held manually. The combination of manual file handle keeping and manual use of SourceManager as a context manager seems error prone. This needs review and possibly revision.

## Todos

- The cache in the singleton is not locked/thread-safe... but so far in ngen there should not be multiple threads within a single process so this is moot... add protection for multi-thread execution anyway?

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Target Environment support

- [X] Linux

